### PR TITLE
go: fix Go self-call schema names and cover dependency use

### DIFF
--- a/cmd/codegen/generator/go/templates/introspect_emit.go
+++ b/cmd/codegen/generator/go/templates/introspect_emit.go
@@ -154,7 +154,7 @@ func introspectObject(spec *parsedObjectType) *introspection.Type {
 			continue
 		}
 		field := &introspection.Field{
-			Name:        f.name,
+			Name:        strcase.ToLowerCamel(f.name),
 			Description: strings.TrimSpace(f.doc),
 			TypeRef:     introspectTypeRef(f.typeSpec),
 			Args:        introspection.InputValues{},

--- a/core/integration/module_self_calls_test.go
+++ b/core/integration/module_self_calls_test.go
@@ -53,6 +53,16 @@ func (ModuleSuite) TestSelfCalls(ctx context.Context, t *testctx.T) {
 				require.NoError(t, err)
 				require.JSONEq(t, `{"printDefault":"Hello Self Calls\n"}`, out)
 			})
+
+			if tc.sdk == "go" {
+				t.Run("can expose exported scalar fields", func(ctx context.Context, t *testctx.T) {
+					out, err := modGen.
+						With(daggerQueryAt(".", `{message}`)).
+						Stdout(ctx)
+					require.NoError(t, err)
+					require.JSONEq(t, `{"message":"hello from field"}`, out)
+				})
+			}
 		})
 	}
 }

--- a/core/integration/module_self_calls_test.go
+++ b/core/integration/module_self_calls_test.go
@@ -66,3 +66,45 @@ func (ModuleSuite) TestSelfCalls(ctx context.Context, t *testctx.T) {
 		})
 	}
 }
+
+func (ModuleSuite) TestSelfCallsAsDependency(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen := moduleFixture(t, c, "go/self-calls-as-dep")
+
+	t.Run("can call dependency function that self-calls", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerQueryAt(".", `{viaDep(stringArg:"hello")}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"viaDep":"direct-hello\n"}`, out)
+	})
+
+	t.Run("can use object returned by dependency self-call", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerQueryAt(".", `{viaDepContainer(stringArg:"hello")}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"viaDepContainer":"container-hello\n"}`, out)
+	})
+
+	t.Run("can self-call from dependency secondary object", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerQueryAt(".", `{viaDepWorker(stringArg:"hello")}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"viaDepWorker":"worker-hello\n"}`, out)
+	})
+}
+
+func (ModuleSuite) TestSelfCallsAsTransitiveDependency(ctx context.Context, t *testctx.T) {
+	c := connect(ctx, t)
+	modGen := moduleFixture(t, c, "go/self-calls-transitive")
+
+	t.Run("can call transitive dependency function that self-calls", func(ctx context.Context, t *testctx.T) {
+		out, err := modGen.
+			With(daggerQueryAt(".", `{viaTransitiveDep(stringArg:"hello")}`)).
+			Stdout(ctx)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"viaTransitiveDep":"transitive-hello\n"}`, out)
+	})
+}

--- a/core/integration/testdata/modules/go/self-calls-as-dep/dagger.json
+++ b/core/integration/testdata/modules/go/self-calls-as-dep/dagger.json
@@ -1,0 +1,17 @@
+{
+  "name": "caller",
+  "engineVersion": "v0.20.6",
+  "sdk": {
+    "source": "go"
+  },
+  "dependencies": [
+    {
+      "name": "dep",
+      "source": "dep"
+    }
+  ],
+  "codegen": {
+    "automaticGitignore": false
+  },
+  "disableDefaultFunctionCaching": true
+}

--- a/core/integration/testdata/modules/go/self-calls-as-dep/dep/dagger.json
+++ b/core/integration/testdata/modules/go/self-calls-as-dep/dep/dagger.json
@@ -1,0 +1,14 @@
+{
+  "name": "dep",
+  "engineVersion": "v0.20.6",
+  "sdk": {
+    "source": "go",
+    "experimental": {
+      "SELF_CALLS": true
+    }
+  },
+  "codegen": {
+    "automaticGitignore": false
+  },
+  "disableDefaultFunctionCaching": true
+}

--- a/core/integration/testdata/modules/go/self-calls-as-dep/dep/main.go
+++ b/core/integration/testdata/modules/go/self-calls-as-dep/dep/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+
+	"dagger/dep/internal/dagger"
+)
+
+func New() *Dep {
+	return &Dep{
+		Base: dag.Container().From("alpine:latest"),
+	}
+}
+
+type Dep struct {
+	Base *dagger.Container
+}
+
+func (m *Dep) ContainerEcho(stringArg string) *dagger.Container {
+	return m.Base.WithExec([]string{"echo", stringArg})
+}
+
+func (m *Dep) Print(ctx context.Context, stringArg string) (string, error) {
+	return dag.Dep().ContainerEcho(stringArg).Stdout(ctx)
+}
+
+func (m *Dep) ViaSelfContainer(stringArg string) *dagger.Container {
+	return dag.Dep().ContainerEcho(stringArg)
+}
+
+func (m *Dep) Worker() *Worker {
+	return &Worker{}
+}
+
+type Worker struct{}
+
+func (w *Worker) Echo(ctx context.Context, stringArg string) (string, error) {
+	return dag.Dep().ContainerEcho(stringArg).Stdout(ctx)
+}

--- a/core/integration/testdata/modules/go/self-calls-as-dep/main.go
+++ b/core/integration/testdata/modules/go/self-calls-as-dep/main.go
@@ -1,0 +1,17 @@
+package main
+
+import "context"
+
+type Caller struct{}
+
+func (m *Caller) ViaDep(ctx context.Context, stringArg string) (string, error) {
+	return dag.Dep().Print(ctx, "direct-"+stringArg)
+}
+
+func (m *Caller) ViaDepContainer(ctx context.Context, stringArg string) (string, error) {
+	return dag.Dep().ViaSelfContainer("container-" + stringArg).Stdout(ctx)
+}
+
+func (m *Caller) ViaDepWorker(ctx context.Context, stringArg string) (string, error) {
+	return dag.Dep().Worker().Echo(ctx, "worker-"+stringArg)
+}

--- a/core/integration/testdata/modules/go/self-calls-transitive/dagger.json
+++ b/core/integration/testdata/modules/go/self-calls-transitive/dagger.json
@@ -1,0 +1,17 @@
+{
+  "name": "caller",
+  "engineVersion": "v0.20.6",
+  "sdk": {
+    "source": "go"
+  },
+  "dependencies": [
+    {
+      "name": "middle",
+      "source": "middle"
+    }
+  ],
+  "codegen": {
+    "automaticGitignore": false
+  },
+  "disableDefaultFunctionCaching": true
+}

--- a/core/integration/testdata/modules/go/self-calls-transitive/main.go
+++ b/core/integration/testdata/modules/go/self-calls-transitive/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "context"
+
+type Caller struct{}
+
+func (m *Caller) ViaTransitiveDep(ctx context.Context, stringArg string) (string, error) {
+	return dag.Middle().ViaDep(ctx, stringArg)
+}

--- a/core/integration/testdata/modules/go/self-calls-transitive/middle/dagger.json
+++ b/core/integration/testdata/modules/go/self-calls-transitive/middle/dagger.json
@@ -1,0 +1,17 @@
+{
+  "name": "middle",
+  "engineVersion": "v0.20.6",
+  "sdk": {
+    "source": "go"
+  },
+  "dependencies": [
+    {
+      "name": "dep",
+      "source": "dep"
+    }
+  ],
+  "codegen": {
+    "automaticGitignore": false
+  },
+  "disableDefaultFunctionCaching": true
+}

--- a/core/integration/testdata/modules/go/self-calls-transitive/middle/dep/dagger.json
+++ b/core/integration/testdata/modules/go/self-calls-transitive/middle/dep/dagger.json
@@ -1,0 +1,14 @@
+{
+  "name": "dep",
+  "engineVersion": "v0.20.6",
+  "sdk": {
+    "source": "go",
+    "experimental": {
+      "SELF_CALLS": true
+    }
+  },
+  "codegen": {
+    "automaticGitignore": false
+  },
+  "disableDefaultFunctionCaching": true
+}

--- a/core/integration/testdata/modules/go/self-calls-transitive/middle/dep/main.go
+++ b/core/integration/testdata/modules/go/self-calls-transitive/middle/dep/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+
+	"dagger/dep/internal/dagger"
+)
+
+func New() *Dep {
+	return &Dep{
+		Base: dag.Container().From("alpine:latest"),
+	}
+}
+
+type Dep struct {
+	Base *dagger.Container
+}
+
+func (m *Dep) ContainerEcho(stringArg string) *dagger.Container {
+	return m.Base.WithExec([]string{"echo", stringArg})
+}
+
+func (m *Dep) Print(ctx context.Context, stringArg string) (string, error) {
+	return dag.Dep().ContainerEcho(stringArg).Stdout(ctx)
+}

--- a/core/integration/testdata/modules/go/self-calls-transitive/middle/main.go
+++ b/core/integration/testdata/modules/go/self-calls-transitive/middle/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "context"
+
+type Middle struct{}
+
+func (m *Middle) ViaDep(ctx context.Context, stringArg string) (string, error) {
+	return dag.Dep().Print(ctx, "transitive-"+stringArg)
+}

--- a/core/integration/testdata/modules/go/self-calls/main.go
+++ b/core/integration/testdata/modules/go/self-calls/main.go
@@ -6,7 +6,13 @@ import (
 	"dagger/test/internal/dagger"
 )
 
-type Test struct{}
+type Test struct {
+	Message string
+}
+
+func New() *Test {
+	return &Test{Message: "hello from field"}
+}
 
 func (m *Test) ContainerEcho(
 	// +optional


### PR DESCRIPTION
This PR is a follow-up against eunomie's `workspace-go-no-codegen-at-runtime` branch.

That branch changes how Go modules with SELF_CALLS provide the schema used to generate their own Go client. My manual review led to those findings:
- Go self-calls worked when called directly.
- Go self-calls also worked when the SELF_CALLS module was used as a dependency.
- They also worked through a transitive dependency.
- A **separate real issue showed up with exported fields**.

#### The actual bug

A Go module can expose fields on its root object:
```go
type Test struct {
  Message string
}
```

The engine exposes that field as message, but the new self-call schema emitter was exposing it as Message.

That mismatch can break the generated Go client. In the failing case, generated code could end up with a field and a method using the same Go name, so the code would not compile.

What changed:
- Emit exported fields in the self-call schema with the same name the engine uses --> `Message` now becomes `message`.
- Extend the existing Go self-call fixture with a Message field.
- Add an integration test that queries message, proving the generated client compiles and the schema name is correct.
- Add dependency fixtures to lock down the review concern even though the exact reported failure did not reproduce.

Dependency coverage added:
- `caller` -> `dep`
- `caller` -> `middle` -> `dep`

The dep module is the only module with SELF_CALLS enabled. That keeps the tests focused on the case from the review.

The new tests verify:
- a dependency function can self-call through dag.Dep()
- a container returned by a dependency self-call is still usable by the caller
- self-calls also work from a secondary object
- self-calls work when the SELF_CALLS module is a transitive dependency

Tested with:
```shell
dagger call engine-dev test --pkg ./core/integration --run '^TestModule/TestSelfCalls' --test-verbose --count=1 --failfast --timeout=20m
```

Result: 17 passed.